### PR TITLE
Removing else statements of (default) arguments

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -30,14 +30,10 @@ module.exports = function (grunt) {
 
 		if (opt.src) {
 			opt.src = grunt.template.process(opt.src);
-		} else {
-			opt.src = '.';
 		}
 
 		if (opt.dest) {
 			opt.dest = grunt.template.process(opt.dest);
-		} else {
-			opt.dest = './_site';
 		}
 
 		if (opt.bundleExec) {
@@ -54,8 +50,6 @@ module.exports = function (grunt) {
 
 		if (opt.auto) {
 			command += ' --auto';
-		} else {
-			command += ' --no-auto';
 		}
 
 		if (opt.server) {
@@ -87,8 +81,6 @@ module.exports = function (grunt) {
 
 		if (opt.future) {
 			command += ' --future';
-		} else {
-			command += ' --no-future';
 		}
 
 		if (opt.lsi) {


### PR DESCRIPTION
All default values are already defined with [`Jekyll::DEFAULTS`](https://github.com/mojombo/jekyll/blob/master/lib/jekyll.rb#L53). Or just using a `_config.yml` to define more arguments and options, which are not provided by grunt-jekyll. There is no need to reference to `_config.yml`, because Jekyll will check this file in grunt-jekyll's root directory by default.
