### PR TITLE
Add in config option

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -105,7 +105,6 @@ module.exports = function (grunt) {
 
 		if (opt.config) {
 			command += ' --config ' + opt.config;
-			grunt.log.write(opt.config);
 		}
 
 		function puts(error, stdout, stderr) {


### PR DESCRIPTION
This adds in an option to select what config file to use. 

Use case:
I have two grunt scripts, one for deployment and one for development. For the development, I have a few settings in jekyll changed so that I can output some development code (like livereload) into my page. 
