### PR TITLE
Document bundle exec option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ Listen at the given hostname (requires `server`).
 
 Serve the website from the given base URL (requires `server`).
 
+#### bundleExec `boolean`
+
+Run `jekyll` with [bundle exec](http://gembundler.com/v1.3/man/bundle-exec.1.html).
+
 ## To-do
 
  - Provide in-line code examples to this readme.


### PR DESCRIPTION
`bundleExec` is working fine, just not documented.
