### PR TITLE
Add editor and code standards helper files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,18 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": false,
+  "curly": false,
+  "eqeqeq": true,
+  "eqnull": true,
+  "immed": true,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "undef": true,
+  "strict": false,
+  "trailing": true,
+  "smarttabs": true
+}


### PR DESCRIPTION
Add an `.editorconfig` and `.jshintrc` to keep code styles consistant between contributors.
