### PR TITLE
Add 'use strict'

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -1,4 +1,5 @@
 /*global module*/
+'use strict';
 module.exports = function (grunt) {
 
 	// Create a new multi task.


### PR DESCRIPTION
Because if a node user wants they can force it, and it's good to remove the bad parts of javascript anyways :).
