### PR TITLE
Add `raw` option

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
 	"engines": {
 		"node": ">= 0.10.5"
 	},
-	"dependencies": {},
+	"dependencies": {
+    "tmp": "0.0.16"
+  },
 	"devDependencies": {
 		"grunt": ">= 0.4.1"
 	},

--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -1,79 +1,106 @@
 /*global module*/
 module.exports = function (grunt) {
+	var fs = require('fs');
+	var tmp = require('tmp');
+	var exec = require('child_process').exec;
 
-	// Create a new multi task.
+	// Create a new multi task
 	grunt.registerMultiTask('jekyll', 'This triggers the `jekyll` command.', function () {
+		var done = this.async();
+		var options = Object.keys(this.options()).length ? this.options() : this.data;
+		var command = 'jekyll';
+		var optionList = {
+			'src': '--source',
+			'dest': '--destination',
+			'safe': '--safe',
+			'plugins': '--plugins',
+			'layouts': '--layouts',
+			'watch': '--watch',
+			'auto': '--watch',
+			'config': '--config',
+			'drafts': '--drafts',
+			'future': '--future',
+			'lsi': '--lsi',
+			'limit_posts': '--limit_posts',
+			'port': '--port',
+			'server_port': '--port',
+			'host': '--host',
+			'baseurl': '--baseurl',
 
-		// Tell grunt this task is asynchronous.
-		var done = this.async(),
-			exec = require('child_process').exec,
-			command = 'jekyll',
+			// Deprecated flags
+			'paginate': false,
+			'permalink': false,
+			'markdown': false,
+			'url': false
+		};
 
-			optionList = {
-				'src': '--source',
-				'dest': '--destination',
-				'safe': '--safe',
-				'plugins': '--plugins',
-				'layouts': '--layouts',
-				'watch': '--watch',
-				'auto': '--watch',
-				'config': '--config',
-				'drafts': '--drafts',
-				'future': '--future',
-				'lsi': '--lsi',
-				'limit_posts': '--limit_posts',
-				'port': '--port',
-				'server_port': '--port',
-				'host': '--host',
-				'baseurl': '--baseurl',
+		// Create temporary config file if needed
+		function configContext (cb) {
+			if (options.raw) {
+				tmp.file({ prefix: '_config.', postfix: '.yml' }, function (err, path, fd) {
+					if (err) {
+						return cb(err);
+					}
 
-				// deprecated flags
-				'paginate': false,
-				'permalink': false,
-				'markdown': false,
-				'url': false
-			},
+					fs.writeSync(fd, new Buffer(options.raw), 0, options.raw.length);
 
-		// Support 'options' and bare style configuration
-		options = Object.keys(this.options()).length ? this.options() : this.data;
-
-		if (options.bundleExec) {
-			command = 'bundle exec ' + command;
-		}
-
-		if (options.server) {
-			command += ' serve';
-		} else {
-			command += ' build';
-		}
-
-		// Add optionList options to command
-		Object.keys(optionList).forEach(function (option) {
-			if (options[option]) {
-				command += ' ' + optionList[option];
-				if (typeof options[option] !== 'boolean') {
-					command += ' ' + options[option];
-				}
-				if (!options[option]) {
-					grunt.warn('`' + option + '` has been deprecated. You may want to try this option in the configuration file.');
-				}
-			}
-		});
-
-		function puts(error, stdout, stderr) {
-
-			grunt.log.write('\n\nJekyll output:\n');
-			grunt.log.write(stdout);
-
-			if (error) {
-				grunt.log.error(error);
-				done(false);
+					cb(null, path);
+				});
 			} else {
-				done(true);
+				cb(null, null);
 			}
 		}
 
-		exec(command, puts);
-		grunt.log.write('`' + command + '` was initiated.');
+		// Run configContext with command processing and execution as a callback
+		configContext(function (err, path) {
+			if (err) {
+				grunt.fail.warn(err);
+			}
+
+			// Build the command string
+			if (options.bundleExec) {
+				command = 'bundle exec ' + command;
+			}
+
+			if (options.server) {
+				command += ' serve';
+			} else {
+				command += ' build';
+			}
+
+			// Insert temporary config path into the config option
+			if (path) {
+				options.config = options.config ? options.config + ',' + path : path;
+			}
+
+			// Add flags to command
+			Object.keys(optionList).forEach(function (option) {
+				if (options[option]) {
+					command += ' ' + optionList[option];
+					if (typeof options[option] !== 'boolean') {
+						command += ' ' + options[option];
+					}
+					if (!options[option]) {
+						grunt.warn('`' + option + '` has been deprecated. You may want to try this in the `raw` option in your gruntfile, or in a configuration file.');
+					}
+				}
+			});
+
+			// Execute command
+			exec(command, function (err, stdout) {
+
+				grunt.log.write('\n\nJekyll output:\n');
+				grunt.log.write(stdout);
+
+				if (err) {
+					grunt.fail.warn(err);
+					done(false);
+				} else {
+					done(true);
+				}
+			});
+
+			grunt.log.write('`' + command + '` was initiated.');
+		});
 	});
 };


### PR DESCRIPTION
This adds a `raw` option to the plugin. Raw lets you add any values to a temporary _config.yml, which is then added to the `--config` cascade. For example:

``` js
dist: {
  options: {
    dest: '<%= yeoman.dist %>',
    config: '_config.yml,_config.build.yml',
    raw: 'author:' +
   '\n  name: Rob Wierzbowski' +
   '\n  email: hello@robwierzbowski.com' +
   '\npygments: false'
  }
}
```

creates a temporary _config.HASH.yml file containing:

``` yml
author:
  name: Rob Wierzbowski
  email: hello@robwierzbowski.com
pygments: false
```

and adds it to the command like so:

```
// Terminal output
Running "jekyll:dist" (jekyll) task
`jekyll build --source app --destination dist --config _config.yml,_config.build.yml,/var/folders/9x/mtztd0zj7gzd7b6kfll1r4jh0000gn/T/_config.8194l7agv9s.yml` was initiated.

Jekyll output:
Configuration file: _config.yml
Configuration file: _config.build.yml
Configuration file: /var/folders/9x/mtztd0zj7gzd7b6kfll1r4jh0000gn/T/_config.8194l7agv9s.yml
            Source: app
       Destination: dist
      Generating... done.
```

The temp file is cleaned up on process end. 

So using this you can set non-command line properties in the Gruntfile, including any custom properties you like for templating, etc.

---

**Couple notes:**
- Based on raw in [grunt-contrib-compass](https://github.com/gruntjs/grunt-contrib-compass).
- This continues from and includes the commits in https://github.com/dannygarcia/grunt-jekyll/pull/14, but isn't necessarily tied to it. If you pull or decline that PR I'll rebase this one. I included the commits for now so if you want you can play around with a working branch.
- Will need docs, which I can write up.
- Should play well with my other small PRs.
