### PR TITLE
log the error when `jekyll -v` fails

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -43,6 +43,7 @@ module.exports = function (grunt) {
 			exec(versionCommand, function (error, stdout, stderr) {
 
 				if (error) {
+					grunt.log.error(error);
 					grunt.fail.warn('Please install Jekyll before running this task.');
 					done(false);
 				}


### PR DESCRIPTION
Hey, I'm currently trying to debug [a very weird bug involving grunt-jekyll and Travis](https://travis-ci.org/twbs/bootstrap/jobs/15474125). It would help greatly if grunt-jekyll would output the error it encounters when `jekyll -v` fails. This PR makes it output the error.
