### PR TITLE
Adding --source on doctor.

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -114,6 +114,11 @@ module.exports = function (grunt) {
 					}
 				});
 			}
+			else {
+				if (options.src) {
+					command += ' ' + optionList.src + ' ' + options.src;
+				}
+			}
 
 			// Execute command
 			grunt.log.write('`' + command + '` was initiated.\n');


### PR DESCRIPTION
This fixes #48 and the problem Windows users have when using `jekyll doctor` in conjunction with grunt-contrib-imagemin. Tried this on generator-jekyllrb and it at least fixes my problem.

Perhaps any cleaner methods for fixing this problem?