### PR TITLE
Added support for the --no-watch flag

### DIFF
--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
 			'plugins': '--plugins',
 			'layouts': '--layouts',
 			'watch': '--watch',
-      'nowatch': '--no-watch',
+      			'nowatch': '--no-watch',
 			'auto': '--watch',
 			'config': '--config',
 			'drafts': '--drafts',

--- a/tasks/jekyll.js
+++ b/tasks/jekyll.js
@@ -17,6 +17,7 @@ module.exports = function (grunt) {
 			'plugins': '--plugins',
 			'layouts': '--layouts',
 			'watch': '--watch',
+      'nowatch': '--no-watch',
 			'auto': '--watch',
 			'config': '--config',
 			'drafts': '--drafts',


### PR DESCRIPTION
I was having issues running jekyll on a VPS server where i wasn't ableto modify the `fs.inotify.max_user_watches` value. Adding the --no-watch flag to `jekyll serve` resolved this issue but grunt-jekyll didn't support this flag.